### PR TITLE
Feature/add delegate stake action

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ I am aware that there are a few places where I cna improve the bot. For example,
 Avaible actions: 
  * Balance -> reading all the lelve 2 tokens balance and staked balance
  * Stake -> moves desired amount to stake.
+ * DelegateStake -> delegate desired amount to a give account could
+ * Flush -> all actions, like stake and delegate stake, does not execute on the spot so the bot does not have the problem of trying to write multiple message in the same block which can cause error
 
 # Amount Calculation 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ I am aware that there are a few places where I cna improve the bot. For example,
           }
         },
         {
+          "name": "Flush"
+        },
+        {
           "name": "Balance"
         },
         {

--- a/build/build.yml
+++ b/build/build.yml
@@ -13,7 +13,7 @@ trigger:
 pool:
   vmImage: ubuntu-latest
 
-name: 0.1.0-$(Rev:r)
+name: 0.2.0-$(Rev:r)
 
 stages:
   - stage: Build

--- a/build/build.yml
+++ b/build/build.yml
@@ -9,6 +9,7 @@ trigger:
       - README.md
       - .build/*
       - .editorconfig
+      - .gitignore
 
 pool:
   vmImage: ubuntu-latest

--- a/src/Functional.HiveUniversalBot.Core/Actions/DelegateStake.fs
+++ b/src/Functional.HiveUniversalBot.Core/Actions/DelegateStake.fs
@@ -1,0 +1,49 @@
+﻿module DelegateStake 
+
+open Core
+open PipelineResult
+open Functional.ETL.Pipeline
+
+[<Literal>]
+let ModuleName = "DelegateStake"
+
+let private getTokenStakeBalance tokensName entity = 
+    let key = sprintf "%s_stake" tokensName
+    match (PipelineProcessData.readPropertyAsDecimal entity key) with 
+    | Some x -> x
+    | _ -> 0M
+
+let private buildCustomJson (hive: Hive) username delegateTo tokenSymbol tokenBalance =
+    let json =
+        sprintf 
+            """{"contractName":"tokens","contractAction":"delegate","contractPayload":{"to":"%s","symbol":"%s","quantity":"%M"}}"""
+            delegateTo 
+            tokenSymbol 
+            tokenBalance
+    hive.createCustomJsonActiveKey username "ssc-mainnet-hive" json
+
+let private delegateStakeTokens tokenSymbol operation = 
+    HiveOperation (ModuleName, tokenSymbol, KeyRequired.Active, operation)
+    //let transactionId = hive.brodcastTransaction operation key 
+    //Processed (ModuleName, transactionId) 
+
+let action hive tokenSymbol delegateTo amountCalcualtor (entity: PipelineProcessData<UniversalHiveBotResutls>) = 
+    let userDetails: (string * string * string) option = PipelineProcessData.readPropertyAsType entity "userdata" 
+
+    match userDetails with 
+    | Some (username, activeKey, _) -> 
+        let tokenBalance = entity |> getTokenStakeBalance tokenSymbol |> amountCalcualtor
+        if tokenBalance > 0M
+        then 
+            let customJson = buildCustomJson hive username delegateTo tokenSymbol tokenBalance
+            delegateStakeTokens tokenSymbol customJson |> PipelineProcessData.withResult entity 
+        else 
+            TokenBalanceTooLow (ModuleName, tokenSymbol) |> PipelineProcessData.withResult entity
+    | _ -> 
+        NoUserDetails ModuleName |> PipelineProcessData.withResult entity
+
+let bind hive urls (parameters: Map<string, string>) = 
+    let token = parameters.["token"]
+    let delegateTo = parameters.["delegateTo"]
+    let amount = parameters.["amount"] |> AmountCalator.bind
+    action hive token delegateTo amount

--- a/src/Functional.HiveUniversalBot.Core/Actions/FlushTokens.fs
+++ b/src/Functional.HiveUniversalBot.Core/Actions/FlushTokens.fs
@@ -1,0 +1,59 @@
+﻿module FlushTokens 
+
+open Core
+open PipelineResult
+open Functional.ETL.Pipeline
+
+[<Literal>]
+let private ModuleName = "Flush"
+ 
+let private isHiveOperation result = 
+    match result with 
+    | HiveOperation _ -> true
+    | _ -> false
+
+let private selectHiveOperationOnly result = 
+    match result with 
+    | HiveOperation (moduleRequesting, token, requiredKey, customJson) -> Some (moduleRequesting, token, requiredKey, customJson :> obj)
+    | _ -> None
+
+let private extractOperations entity =
+    entity.results
+    |> Seq.map selectHiveOperationOnly
+    |> Seq.filter (fun x -> x.IsSome)
+    |> Seq.map (fun x -> x.Value)
+    |> Seq.groupBy (fun (_, _, requiredKey, _) -> requiredKey)
+
+let private executeOperations (hive: Hive) keyRequired operations = 
+    hive.brodcastTransactions operations keyRequired
+
+let private extractCustomJson hiveOperationRequest = 
+    let (_, _, _, customJson) = hiveOperationRequest
+    customJson
+
+let private processHiveOperations hive requiredKey key (operations: Map<KeyRequired,seq<Module * Token * KeyRequired * obj>>) = 
+    if operations.ContainsKey (requiredKey)
+    then 
+        operations.[requiredKey] |> Seq.map extractCustomJson |> Array.ofSeq |> executeOperations hive key |> ignore
+
+let action (hive: Hive) (entity: PipelineProcessData<UniversalHiveBotResutls>) = 
+    let userDetails: (string * string * string) option = PipelineProcessData.readPropertyAsType entity "userdata" 
+
+    match userDetails with 
+    | Some (username, activeKey, postingKey) -> 
+        let operations = extractOperations entity |> Map.ofSeq
+
+        operations |> processHiveOperations hive KeyRequired.Active activeKey 
+        operations |> processHiveOperations hive KeyRequired.Posting postingKey
+
+        let results = 
+            entity.results 
+            |> Seq.filter (fun x -> not (isHiveOperation x))
+            |> List.ofSeq
+
+        { entity with results = results }
+    | _ -> 
+        NoUserDetails ModuleName |> PipelineProcessData.withResult entity
+
+let bind hive urls (parameters: Map<string, string>) = 
+    action hive

--- a/src/Functional.HiveUniversalBot.Core/Actions/StakeToken.fs
+++ b/src/Functional.HiveUniversalBot.Core/Actions/StakeToken.fs
@@ -21,20 +21,21 @@ let private buildCustomJson (hive: Hive) username tokenSymbol tokenBalance =
             tokenBalance
     hive.createCustomJsonActiveKey username "ssc-mainnet-hive" json
 
-let private stakeTokens (hive: Hive) operation key = 
-    let transactionId = hive.brodcastTransaction operation key 
-    Processed (ModuleName, transactionId) 
+let private stakeTokens tokenSymbol operation = 
+    HiveOperation (ModuleName, tokenSymbol, KeyRequired.Active, operation)
+    //let transactionId = hive.brodcastTransaction operation key 
+    //Processed (ModuleName, transactionId) 
 
 let action hive tokenSymbol amountCalcualtor (entity: PipelineProcessData<UniversalHiveBotResutls>) = 
     let userDetails: (string * string * string) option = PipelineProcessData.readPropertyAsType entity "userdata" 
 
     match userDetails with 
-    | Some (username, activeKey, _) -> 
+    | Some (username, _, _) -> 
         let tokenBalance = entity |> getTokenBalance tokenSymbol |> amountCalcualtor
         if tokenBalance > 0M
         then 
             let customJson = buildCustomJson hive username tokenSymbol tokenBalance
-            stakeTokens hive customJson activeKey |> PipelineProcessData.withResult entity 
+            stakeTokens tokenSymbol customJson |> PipelineProcessData.withResult entity 
         else 
             TokenBalanceTooLow (ModuleName, tokenSymbol) |> PipelineProcessData.withResult entity
     | _ -> 

--- a/src/Functional.HiveUniversalBot.Core/Configuration.fs
+++ b/src/Functional.HiveUniversalBot.Core/Configuration.fs
@@ -27,6 +27,8 @@ let private getActionByName (name: string) =
     match name.ToLower() with 
     | "stake" -> StakeToken.bind
     | "balance" -> Level2Balance.bind
+    | "delegatestake" -> DelegateStake.bind
+    | "flush" -> FlushTokens.bind
     | _ -> (fun hive url properties -> Transformer.defaultTransformer<PipelineResult.UniversalHiveBotResutls>)
 
 let private bindActions hive url parameters bindingFunctionName =

--- a/src/Functional.HiveUniversalBot.Core/Functional.HiveUniversalBot.Core.fsproj
+++ b/src/Functional.HiveUniversalBot.Core/Functional.HiveUniversalBot.Core.fsproj
@@ -11,6 +11,8 @@
         <Compile Include="PipelineResult.fs" />
         <Compile Include="Types.fs" />
         <Compile Include="AmountCalator.fs" />
+        <Compile Include="Actions\FlushTokens.fs" />
+        <Compile Include="Actions\DelegateStake.fs" />
         <Compile Include="Actions\StakeToken.fs" />
         <Compile Include="Actions\Level2Balance.fs" />
         <Compile Include="Actions\UserReader.fs" />

--- a/src/Functional.HiveUniversalBot.Core/Hive.fs
+++ b/src/Functional.HiveUniversalBot.Core/Hive.fs
@@ -27,5 +27,5 @@ type Hive (hiveNodeUrl) =
     member this.brodcastTransaction operation key = 
         hive.broadcast_transaction ([| operation |], [| key |])
 
-        member this.brodcastTransactions operations key = 
-            hive.broadcast_transaction ( operations, [| key |])
+    member this.brodcastTransactions operations key = 
+        hive.broadcast_transaction ( operations, [| key |])

--- a/src/Functional.HiveUniversalBot.Core/PipelineResult.fs
+++ b/src/Functional.HiveUniversalBot.Core/PipelineResult.fs
@@ -12,7 +12,7 @@ type KeyRequired =
 type UniversalHiveBotResutls =
     | Unknow
     | NoUserDetails of Module
-    //| (*HiveOperation*) of Module * Token * KeyRequired * CustomJson
+    | HiveOperation of Module * Token * KeyRequired * CustomJson
     | TokenBalanceTooLow of Module * Token 
     | Processed of Module * Item 
     | UnableToProcess of Module * Item * Message


### PR DESCRIPTION
Added new actions to delegate stake to another account. Additionally, I have rewritten the way actions are executed so they are all gathered and then passed to hive.brodcast_transaction command instead of exiting then when ready so their chance of having two transactions in the same block is smaller.